### PR TITLE
Add new comparator stringscontains

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -98,6 +98,8 @@ func (rf *RulerRule) compare(comp int, value interface{}) *RulerRule {
 		comparator = "matches"
 	case ncontains:
 		comparator = "ncontains"
+	case stringscontains:
+		comparator = "stringscontains"
 	}
 
 	// if this thing has a comparator already, we need to make a new ruler filter

--- a/ruler_test.go
+++ b/ruler_test.go
@@ -100,7 +100,6 @@ func TestRules(t *testing.T) {
 			},
 			"testing less than or equal to (int)",
 		},
-
 		{
 			[]*Rule{
 				&Rule{
@@ -115,6 +114,21 @@ func TestRules(t *testing.T) {
 				},
 			},
 			"testing regexp",
+		},
+		{
+			[]*Rule{
+				&Rule{
+					"stringscontains",
+					"basic.property",
+					[]string{"p1", "p2"},
+				},
+			},
+			map[string]interface{}{
+				"basic": map[string]interface{}{
+					"property": "p1",
+				},
+			},
+			"testing stringscontains for []string",
 		},
 	}
 


### PR DESCRIPTION
Hello,

I would like to propose a new comparator `stringscontains`. It takes a string array as a Rule value, and checks if the string value in the path is in the Rule array.

For example:
```
Rule:
{
  "comparator": "arycontains",
  "path": "basic.property",
  "value": ["p1", "p2"]
}
```